### PR TITLE
fix TLS wildcard parsing

### DIFF
--- a/wekan/templates/ingress.yaml
+++ b/wekan/templates/ingress.yaml
@@ -23,7 +23,7 @@ spec:
   {{- range .Values.ingress.tls }}
     - hosts:
       {{- range .hosts }}
-        - {{ . }}
+        - {{ . | quote }}
       {{- end }}
       secretName: {{ .secretName }}
   {{- end }}


### PR DESCRIPTION
The asterisk used in wildcard TLS domain names will cause the following parsing error:
`error converting YAML to JSON: yaml: line 16: did not find expected alphabetic or numeric character`

This PR fixes the parsing error by dynamically quoting the input.

Please feel free to get acquainted with this issue and the fix by looking at the following links:
- https://stackoverflow.com/questions/71170639/error-converting-yaml-to-json-yaml-line-15-did-not-find-expected-alphabetic-o
- https://github.com/k8s-at-home/library-charts/blob/main/charts/stable/common/templates/classes/_ingress.tpl