### PR TITLE
improvement(secretEnv) : Modify secret and deployment to allow users to provide secretEnv with empty value.

### DIFF
--- a/wekan/templates/deployment.yaml
+++ b/wekan/templates/deployment.yaml
@@ -50,13 +50,11 @@ spec:
           {{- end }}
           {{- end }}
           {{- range $key := .Values.secretEnv }}
-          {{- if .value }}
             - name: {{ .name }}
               valueFrom:
                 secretKeyRef:
                   name: {{ template "wekan.fullname" $ }}-secret
                   key: {{ .name }}
-          {{- end }}
           {{- end }}
           livenessProbe:
             httpGet:

--- a/wekan/templates/secret.yaml
+++ b/wekan/templates/secret.yaml
@@ -1,11 +1,13 @@
 {{ if .Values.secretEnv }}
+{{- range $key := .Values.secretEnv }}
+{{ if $key.value }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "wekan.fullname" $ }}-secret
 type: Opaque
 data:
-  {{- range $key := .Values.secretEnv }}
-  {{ $key.name }}: {{ $key.value | b64enc }}
-  {{- end}}
+{{ $key.name }}: {{ $key.value | b64enc }}
+{{ end }}
+{{- end}}
 {{ end }}

--- a/wekan/values.yaml
+++ b/wekan/values.yaml
@@ -35,7 +35,7 @@ env:
 ##
 secretEnv: {}
   # - name: ""
-  #   value: ""
+  ##  value: ""
 
 service:
   type: ClusterIP


### PR DESCRIPTION
This permit to provide secrets afterward (with CD for instance) without having to manually edit secret which often leads
to OutOfSync secret in CD.

Usage is as follows :
```
secretEnv:
  - name: foo
     value: bar
```

-> Actual behaviour

```
secretEnv:
  - name: foo
   # value: bar
```

-> Add secretMapKeyRef in deployment manifest but leaves secret creation to users.