### PR TITLE
feat: add in-memory cache folder for /data

### DIFF
--- a/wekan/templates/deployment.yaml
+++ b/wekan/templates/deployment.yaml
@@ -63,6 +63,11 @@ spec:
               path: /
               port: 8080
             initialDelaySeconds: 60
+          {{ if .Values.cacheFolder.enabled }}
+          volumeMounts:
+            - name: cache-volume
+              mountPath: /data
+          {{ end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}
@@ -77,3 +82,10 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+      {{ if .Values.cacheFolder.enabled }}
+      volumes:
+      - name: cache-volume
+        emptyDir:
+          medium: "Memory"
+          sizeLimit: {{ .Values.cacheFolder.storage }}
+      {{ end }}

--- a/wekan/values.yaml
+++ b/wekan/values.yaml
@@ -110,6 +110,12 @@ deploymentLabels: {}
 # Optional custom labels for the pods created by the deployment.
 podLabels: {}
 
+# That cache folder (/data) is required to move attachments between MongoDB GridFS and filesystem.
+# Without that setting WeKan does not work properly
+cacheFolder:
+  enabled: true
+  storage: 64Mi
+
 # ------------------------------------------------------------------------------
 # MongoDB:
 # ref: https://github.com/bitnami/charts/blob/master/bitnami/mongodb/values.yaml


### PR DESCRIPTION
as discussed here https://github.com/wekan/charts/issues/14 this is my PR to solve that issue.

I'm using a "in memory" emptyDir, because the folder doesn't contain persistent data, right?
So its created together with the pod, taking some memory and its getting deleted when the pod is deleted.
The data itself resides in the MongoDB database in the end!?