### PR TITLE
add root_url to values.yaml

### DIFF
--- a/wekan/templates/deployment.yaml
+++ b/wekan/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
               containerPort: 8080
           env:
             - name: ROOT_URL
-              value: {{ .Values.root_url | default "https://wekan.local" | quote }}
+              value: {{ .Values.root_url | quote }}
           {{- $mongo_url_is_secret := false }}
           {{- range $key := .Values.secretEnv }}
             {{- if eq .name "MONGO_URL" }}

--- a/wekan/values.yaml
+++ b/wekan/values.yaml
@@ -52,6 +52,11 @@ service:
 ##
 endpoint: wekan.local
 
+## Main URL (including http:// or https://) where your Wekan
+## instance is accessible
+##
+root_url: https://wekan.local
+
 ingress:
   enabled: true
   annotations: {}


### PR DESCRIPTION
fix #22 

The parameter `root_url` needs to be set, so the UI is fully functional. But as it was hidden inside the `deployment.yaml`, but not mentioned in the `values.yaml` file, a user does not know that this can and needs to be set.