### PR TITLE
feat: enable generic envFrom for configMaps or secrets

### DIFF
--- a/wekan/templates/deployment.yaml
+++ b/wekan/templates/deployment.yaml
@@ -74,6 +74,10 @@ spec:
                   name: {{ template "wekan.fullname" $ }}-secret
                   key: {{ .name }}
           {{- end }}
+          envFrom:
+            {{- with .Values.extraEnvFrom }}
+            {{- tpl . $ | nindent 10 }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /

--- a/wekan/values.yaml
+++ b/wekan/values.yaml
@@ -31,6 +31,12 @@ env:
   - name: ""
     value: ""
 
+# Additional environment variables for Wekan mapped from Secret or ConfigMap
+extraEnvFrom: ""
+# extraEnvFrom: |
+#    - secretRef:
+#        name: "{{ template "wekan.fullname" $ }}-test-secret"
+
 ## Specify additional secret environmental variables for the
 ## Deployment. These can e.g. be provided by a Secret and allow
 ## to store passwords separately


### PR DESCRIPTION
Hi we have to set some extra secrets (generated with ExternalSecrets) we want to attach as envFrom

with this PR we can add templated extraEnvFrom generic target like configMap or secret 