### PR TITLE
feat: add updateStrategy

### DIFF
--- a/wekan/templates/deployment.yaml
+++ b/wekan/templates/deployment.yaml
@@ -12,6 +12,8 @@ metadata:
     {{- toYaml .Values.deploymentLabels | nindent 4 }}
     {{- end }}
 spec:
+  strategy:
+  {{ toYaml .Values.updateStrategy | nindent 4 }}
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:

--- a/wekan/values.yaml
+++ b/wekan/values.yaml
@@ -132,6 +132,13 @@ sharedDataFolder:
     requests:
       storage: 5Gi
 
+
+updateStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 1
+    maxSurge: 1
+
 extraDeploy: []
 # ------------------------------------------------------------------------------
 # MongoDB:


### PR DESCRIPTION
Adding the possibility to change the updateStrategy on the Wekan Deployment.

Without the recreate strategy the deployment may get stuck when updating if using RWO PVCs.