### PR TITLE
Add Support for Overriding Image Registry in Airgapped Environments

### DIFF
--- a/wekan/README.md
+++ b/wekan/README.md
@@ -100,3 +100,27 @@ instead of ingress with following command:
 helm template --set route.enabled=true,ingress.enabled=false values.yaml . | \
   oc apply -f-
 ```
+
+# Install with Local Image Registry
+
+To utilize a local Image Registry, configure the following values to point to your local registry:
+
+```yaml
+image:
+  repository: ghcr.io/wekan/wekan
+init:
+  image:
+    repository: docker.io/busybox
+test:
+  image:
+    repository: docker.io/busybox
+```
+
+Additionally, set the Bitnami defaultRegistry to use your local docker.io mirror with the following snippet:
+
+```yaml
+global:
+  imageRegistry: "<your docker.io mirror goes here>"
+```
+
+This setup will ensure that all images are pulled from your specified local registry, optimizing performance and reliability for your deployment environment.

--- a/wekan/templates/deployment.yaml
+++ b/wekan/templates/deployment.yaml
@@ -35,8 +35,8 @@ spec:
       {{- if ne .Values.platform "openshift" }}
       initContainers:
         - name: volume-permissions
-          image: busybox
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.init.image.repository }}:{{ .Values.init.image.tag }}"
+          imagePullPolicy: {{ .Values.init.image.pullPolicy }}
           command: ['sh', '-c', 'chown -R 999:999 /data']
           volumeMounts:
             - name: shared-data-volume

--- a/wekan/templates/tests/test-http.yaml
+++ b/wekan/templates/tests/test-http.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   containers:
     - name: wget
-      image: busybox
+      image: "{{ .Values.init.image.repository }}:{{ .Values.init.image.tag }}"
       command: ['wget', '-O', '/dev/stdout']
       args: ['{{ template "wekan.fullname" . }}:{{ .Values.service.port }}']
   restartPolicy: Never

--- a/wekan/templates/tests/test-http.yaml
+++ b/wekan/templates/tests/test-http.yaml
@@ -13,7 +13,7 @@ metadata:
 spec:
   containers:
     - name: wget
-      image: "{{ .Values.init.image.repository }}:{{ .Values.init.image.tag }}"
+      image: "{{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}"
       command: ['wget', '-O', '/dev/stdout']
       args: ['{{ template "wekan.fullname" . }}:{{ .Values.service.port }}']
   restartPolicy: Never

--- a/wekan/values.yaml
+++ b/wekan/values.yaml
@@ -107,6 +107,10 @@ resources:
     cpu: 500m
 
 init:
+  image:
+    repository: docker.io/busybox
+    tag: latest
+    pullPolicy: IfNotPresent
   resources:
     requests:
       memory: 128Mi
@@ -115,6 +119,10 @@ init:
       memory: 256Mi
       cpu: 100m
 
+test:
+  image:
+    repository: docker.io/busybox
+    tag: latest
 ## Node labels for pod assignment
 ## ref: https://kubernetes.io/docs/user-guide/node-selection/
 ##


### PR DESCRIPTION
This pull request introduces the ability to override the image registries for all images used in the Helm chart. This feature is particularly beneficial for deployments in airgapped environments, where access to external registries is restricted or not available.

- Added a new configuration option that allows users to specify a custom image registry for all components within the chart.
- Updated the README to include instructions on how to configure the chart to use a local image registry.
- Verified that the changes allow for successful image pulling from a specified local registry in an airgapped setup.