### PR TITLE
feat(helm): allow to define securityContext for pod and containers

### DIFF
--- a/wekan/templates/deployment.yaml
+++ b/wekan/templates/deployment.yaml
@@ -32,7 +32,9 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ template "wekan.serviceAccountName" . }}
-      {{- if ne .Values.platform "openshift" }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if and (ne .Values.platform "openshift") (.Values.init.enabled) }}
       initContainers:
         - name: volume-permissions
           image: "{{ .Values.init.image.repository }}:{{ .Values.init.image.tag }}"
@@ -42,7 +44,9 @@ spec:
             - name: shared-data-volume
               mountPath: /data
           resources:
-{{ toYaml .Values.init.resources | indent 12 }}
+            {{- toYaml .Values.init.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.init.podSecurityContext | nindent 12 }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -92,6 +96,8 @@ spec:
               path: /
               port: {{ .Values.service.port }}
             initialDelaySeconds: 60
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           {{ if .Values.sharedDataFolder.enabled }}
           volumeMounts:
             - name: shared-data-volume

--- a/wekan/values.yaml
+++ b/wekan/values.yaml
@@ -107,6 +107,7 @@ resources:
     cpu: 500m
 
 init:
+  enabled: true
   image:
     repository: docker.io/busybox
     tag: latest
@@ -118,6 +119,7 @@ init:
     limits:
       memory: 256Mi
       cpu: 100m
+  securityContext: {}
 
 test:
   image:
@@ -171,6 +173,9 @@ updateStrategy:
   rollingUpdate:
     maxUnavailable: 1
     maxSurge: 1
+
+podSecurityContext: {}
+securityContext: {}
 
 extraDeploy: []
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Allows to define securityContext for enforced restricted security.

In a namespace with label `pod-security.kubernetes.io/enforce: restricted`, wekan and mongodb are not allowed to start.

With the updated chart and these values, it works fine :

```yaml
init:
  enabled: false

podSecurityContext:
  runAsNonRoot: true
  runAsUser: 999
  runAsGroup: 999
  fsGroup: 999
  seccompProfile:
    type: RuntimeDefault

securityContext:
  allowPrivilegeEscalation: false
  capabilities:
    drop:
      - ALL

mongodb:
  podSecurityContext:
    runAsNonRoot: true
```