### PR TITLE
Service account token does not need to be mounted in op

### DIFF
--- a/wekan/templates/deployment.yaml
+++ b/wekan/templates/deployment.yaml
@@ -32,6 +32,7 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ template "wekan.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccounts.automount }}
       {{- if ne .Values.platform "openshift" }}
       initContainers:
         - name: volume-permissions

--- a/wekan/templates/serviceaccount.yaml
+++ b/wekan/templates/serviceaccount.yaml
@@ -13,4 +13,5 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "wekan.serviceAccountName" . }}
+automountServiceAccountToken: {{ .Values.serviceAccounts.automount }}
 {{- end }}

--- a/wekan/values.yaml
+++ b/wekan/values.yaml
@@ -11,6 +11,7 @@ serviceAccounts:
   create: true
   name: ""
   annotations: ""
+  automount: false
 
 ## Wekan image configuration
 ##


### PR DESCRIPTION
Service account token does not need to be mounted in pod.