### PR TITLE
add secretManaged value

### DIFF
--- a/wekan/templates/secret.yaml
+++ b/wekan/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.secretEnv }}
+{{ if .Values.secretManaged }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/wekan/values.yaml
+++ b/wekan/values.yaml
@@ -46,6 +46,8 @@ extraEnvFrom: ""
 secretEnv: {}
   # - name: ""
   ##  value: ""
+## Secret created by Helm if true, or managed externally if false
+secretManaged: true
 
 service:
   type: ClusterIP


### PR DESCRIPTION
Hi, 
I add a parameter to enable or disable the creation of secret by Helm. In my case, the secret is managed by an external tool (sealed-secret). I need to put MONGO_URL in this secret but don't want this value is in my git repository. 