### PR TITLE
fix: restore pod security context in deployment

### DIFF
--- a/wekan/templates/deployment.yaml
+++ b/wekan/templates/deployment.yaml
@@ -31,6 +31,8 @@ spec:
         {{- toYaml .Values.podLabels | nindent 8 }}
         {{- end }}
     spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ template "wekan.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.serviceAccounts.automount }}
       {{- if ne .Values.platform "openshift" }}


### PR DESCRIPTION
Merge commit edcbb314d1ea69e14366f752863ed694b2aeb162 seems to have mistakenly removed the pod security context from the deployment. This restores the security context to the pod template using the chart's `podSecurityContext` value.

Prior to this, a fresh deployment I was setting up was failing due to `fsGroup` not being set even though I had it set in my values file. I looked closer and saw that `podSecurityContext` wasn't actually being referenced at the pod template level in the deployment template. Then I found that merge commit.