### PR TITLE
fix: quote host names

### DIFF
--- a/wekan/templates/ingress.yaml
+++ b/wekan/templates/ingress.yaml
@@ -23,14 +23,14 @@ spec:
   {{- range .Values.ingress.tls }}
     - hosts:
       {{- range .hosts }}
-        - {{ . }}
+        - {{ . | quote }}
       {{- end }}
       secretName: {{ .secretName }}
   {{- end }}
 {{- end }}
   rules:
   {{- range .Values.ingress.hosts }}
-    - host: {{ . }}
+    - host: {{ . | quote }}
       http:
         paths:
           - path: {{ $ingressPath }}


### PR DESCRIPTION
This PR allows for wildcard hostname like `*.example.com`.