### PR TITLE
feat: add podAnnotations support

### DIFF
--- a/wekan/README.md
+++ b/wekan/README.md
@@ -75,6 +75,27 @@ Horizontal Pod Autoscaler (HPA).
 scale-out the number of Wekan pods.
 
 ```yaml
+# Optional custom labels for the pods created by the deployment.
+podLabels: {}
+
+# Optional custom annotations for the pods created by the deployment.
+podAnnotations: {}
+```
+
+**podLabels:** These are custom labels that will be applied to the Wekan pods.
+
+**podAnnotations:** These are custom annotations that will be applied to the Wekan pods.
+This can be useful for integrating with monitoring systems, service meshes, or other Kubernetes tools.
+
+```yaml
+mongodb:
+  # Optional custom annotations for the MongoDB pods
+  podAnnotations: {}
+```
+
+**podAnnotations:** These are custom annotations that will be applied to the MongoDB pods.
+
+```yaml
 mongodb-replicaset:
   enabled: true
   replicas: 3

--- a/wekan/templates/deployment.yaml
+++ b/wekan/templates/deployment.yaml
@@ -23,6 +23,9 @@ spec:
   template:
     metadata:
       annotations:
+        {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+        {{- end }}
       labels:
         app: {{ template "wekan.name" . }}
         component: wekan

--- a/wekan/values.yaml
+++ b/wekan/values.yaml
@@ -161,6 +161,9 @@ deploymentLabels: {}
 # Optional custom labels for the pods created by the deployment.
 podLabels: {}
 
+# Optional custom annotations for the pods created by the deployment.
+podAnnotations: {}
+
 sharedDataFolder:
   enabled: true
   path: /data
@@ -199,3 +202,5 @@ mongodb:
   # Optional specify an existing PVC
   persistence:
     existingClaim: ""
+  # Optional custom annotations for the MongoDB pods
+  podAnnotations: {}


### PR DESCRIPTION
Adds the `podAnnotations` value to the chart, allowing users to specify custom annotations for pods. This enables integration with monitoring systems, service meshes, and other Kubernetes tools that rely on pod annotations. In my case, I need these for automated backups with Velero.

This PR also updates the docs in the readme with information on `podAnnotations` and `podLabels`.