### PR TITLE
feat: make readiness, liveness and startup probes configurable

### DIFF
--- a/wekan/templates/deployment.yaml
+++ b/wekan/templates/deployment.yaml
@@ -91,15 +91,13 @@ spec:
             {{- tpl . $ | nindent 10 }}
             {{- end }}
           readinessProbe:
-            httpGet:
-              path: /
-              port: {{ .Values.service.port }}
-            initialDelaySeconds: 20
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
           livenessProbe:
-            httpGet:
-              path: /
-              port: {{ .Values.service.port }}
-            initialDelaySeconds: 60
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            {{- omit .Values.startupProbe "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           {{ if .Values.sharedDataFolder.enabled }}

--- a/wekan/values.yaml
+++ b/wekan/values.yaml
@@ -109,6 +109,37 @@ resources:
     memory: 1Gi
     cpu: 500m
 
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 20
+  periodSeconds: 10
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 3
+
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 60
+  periodSeconds: 20
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 3
+
+startupProbe:
+  enabled: false
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 30
+
 init:
   enabled: true
   image:


### PR DESCRIPTION
In wekan version 8, some slowness and restarts happened. The default `timeout` is 1 second which may be the cause. The PR will allow users to configure the probes. This change is verified with `helm template` command.